### PR TITLE
Use Org mode buffer settings instead of YAML

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -43,7 +43,12 @@ module Jekyll
         self.data[buffer_setting] = value
       end
 
-      self.content = org_text.to_html
+      # Disable Liquid tags from the output
+      self.content = <<ORG
+{% raw %}
+#{org_text.to_html}
+{% endraw %}
+ORG
       self.extracted_excerpt = self.extract_excerpt
     rescue => e
       puts "Error converting file #{File.join(base, name)}: #{e.message} #{e.backtrace}"


### PR DESCRIPTION
When writing Jekyll posts, we need to include some YAML headers to set the layout and title for the post like:

```
title: something
category: posts
layout: post
```

this works, but ideally I would like to have the whole file using Org mode format. I think Org in buffer settings are a good alternative, so with this PR it is possible to use the following instead:

```
#+title: Replacing Jekyll YAML headers with Org mode buffer settings
#+category: posts
#+layout:   post
```

what do you think?
