### PR TITLE
org file slug

### DIFF
--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -73,7 +73,6 @@ module Jekyll
 ORG
       end
 
-      post_read
     rescue => e
       puts "Error converting file #{relative_path}: #{e.message} #{e.backtrace}"
     end

--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -73,6 +73,7 @@ module Jekyll
 ORG
       end
 
+      post_read
     rescue => e
       puts "Error converting file #{relative_path}: #{e.message} #{e.backtrace}"
     end


### PR DESCRIPTION
Remove an error about post_read.

Add a support for default slug.

Before this pull request, a org file named `2017-01-01-test.org` without `#+slug` will build to `2017-01-01-test.html`.
Now it will build to `test.html` by default, and if a `slug` is supported it will use the `slug`.

See more: [document.rb](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/document.rb#L418-L439)