### PR TITLE
fixes #24 Change HEREDOC multiline string to shorthand multiline

### DIFF
--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -79,11 +79,11 @@ module Jekyll
         self.content = self.content.gsub("&#8216;","'")
         self.content = self.content.gsub("&#8217;", "'")
       else
-        self.content = %q(
-{% raw %}
-#{org_text.to_html}
-{% endraw %}
-)
+        self.content = [
+          '{% raw %}',
+          org_text.to_html,
+          '{% endraw %}'
+        ].join(" ")
       end
       begin
         self.data

--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -79,11 +79,11 @@ module Jekyll
         self.content = self.content.gsub("&#8216;","'")
         self.content = self.content.gsub("&#8217;", "'")
       else
-        self.content = <<ORG
+        self.content = %q(
 {% raw %}
 #{org_text.to_html}
 {% endraw %}
-ORG
+)
       end
       begin
         self.data


### PR DESCRIPTION
fixes #24 

For some reason the HEREDOC syntax is dropping the `{% endraw %}`