### PR TITLE
Parse #+TAGS into a list

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,10 +66,13 @@ with no lines:
 #+BEGIN_EXAMPLE
 #+TITLE: Jekyll and Org together
 #+LAYOUT: post
-#+TAGS: jekyll org-mode
+#+TAGS: jekyll org-mode "tag with spaces"
 
 This is a blog post about Jekyll and Org mode.
 #+END_EXAMPLE
+
+The value of =#+TAGS= is parsed into a list by splitting it on spaces,
+tags containing spaces can be wrapped into quotes.
 
 ** Liquid templating
 

--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -1,3 +1,4 @@
+require 'csv'
 require 'org-ruby'
 
 if Jekyll::VERSION < "3.0"
@@ -59,7 +60,17 @@ module Jekyll
           liquid_enabled = true
         end
 
-        self.data[buffer_setting] = value
+        if buffer_setting == 'tags'
+          # Parse a string of tags separated by spaces into a list.
+          # Tags containing spaces can be wrapped in quotes,
+          # e.g. '#+TAGS: foo "with spaces"'.
+          # 
+          # The easiest way to do this is to use rubys builtin csv parser
+          # and use spaces instead of commas as column separator.
+          self.data[buffer_setting] = CSV::parse_line(value, col_sep: ' ')
+        else
+          self.data[buffer_setting] = value
+        end
       end
       # set default slug
       # copy and edit frmo jekyll:lib/jekyll/document.rb -- populate_title


### PR DESCRIPTION
I've looked through the `org-ruby` code
and it seems like all options values get passed through as strings
without any additional parsing.

`jekyll-org` then sets the tags of the documents to this string
whereas something like `[tag1, tag2]` in a markdown frontmatter
is treated as a list (parsed by the yaml parser).

This pull request changes the way `buffer_setting`s are passed to jekyll
so that the value of `#+TAGS` is parsed into a list first.

I'm not sure if this project uses semantic versioning
and if this change should be considered major.

This should fix issues #33 and #40.