### PR TITLE
Improved variable recognition

### DIFF
--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -60,11 +60,11 @@ module Jekyll
           liquid_enabled = true
         end
 
-        if buffer_setting == 'tags'
+        if (buffer_setting == 'tags' or buffer_setting == 'categories')
           # Parse a string of tags separated by spaces into a list.
           # Tags containing spaces can be wrapped in quotes,
           # e.g. '#+TAGS: foo "with spaces"'.
-          # 
+          #
           # The easiest way to do this is to use rubys builtin csv parser
           # and use spaces instead of commas as column separator.
           self.data[buffer_setting] = CSV::parse_line(value, col_sep: ' ')

--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -68,6 +68,8 @@ module Jekyll
           # The easiest way to do this is to use rubys builtin csv parser
           # and use spaces instead of commas as column separator.
           self.data[buffer_setting] = CSV::parse_line(value, col_sep: ' ')
+        elsif %w[true false].include?(value)
+          self.data[buffer_setting] = value == 'true'
         else
           self.data[buffer_setting] = value
         end

--- a/lib/jekyll-org.rb
+++ b/lib/jekyll-org.rb
@@ -1,8 +1,8 @@
 require 'csv'
 require 'org-ruby'
 
-if Jekyll::VERSION < "3.0"
-  raise Jekyll::FatalException, "This version of jekyll-org is only compatible with Jekyll v3 and above."
+if Jekyll::VERSION < '3.0'
+  raise Jekyll::FatalException, 'This version of jekyll-org is only compatible with Jekyll v3 and above.'
 end
 
 module Jekyll
@@ -16,7 +16,7 @@ module Jekyll
     end
 
     def output_ext(ext)
-      ".html"
+      '.html'
     end
 
     def convert(content)
@@ -50,7 +50,7 @@ module Jekyll
       self.data ||= {}
       liquid_enabled = false
 
-      org_text = Orgmode::Parser.new(content, { markup_file: "html.tags.yml" })
+      org_text = Orgmode::Parser.new(content, { markup_file: 'html.tags.yml' })
       org_text.in_buffer_settings.each_pair do |key, value|
         # Remove #+TITLE from the buffer settings to avoid double exporting
         org_text.in_buffer_settings.delete(key) if key =~ /title/i
@@ -60,7 +60,7 @@ module Jekyll
           liquid_enabled = true
         end
 
-        if (buffer_setting == 'tags' or buffer_setting == 'categories')
+        if %w[tags categories].include?(buffer_setting)
           # Parse a string of tags separated by spaces into a list.
           # Tags containing spaces can be wrapped in quotes,
           # e.g. '#+TAGS: foo "with spaces"'.
@@ -80,21 +80,21 @@ module Jekyll
       elsif relative_path =~ DATELESS_FILENAME_MATCHER
         slug, ext = Regexp.last_match.captures
       end
-      self.data["title"] ||= Utils.titleize_slug(slug)
-      self.data["slug"]  ||= slug
-      self.data["ext"]   ||= ext
+      self.data['title'] ||= Utils.titleize_slug(slug)
+      self.data['slug']  ||= slug
+      self.data['ext']   ||= ext
 
       # Disable Liquid tags from the output by default or enabled with liquid_enabled tag
       if liquid_enabled
         self.content = org_text.to_html
-        self.content = self.content.gsub("&#8216;","'")
+        self.content = self.content.gsub("&#8216;", "'")
         self.content = self.content.gsub("&#8217;", "'")
       else
         self.content = [
           '{% raw %}',
           org_text.to_html,
           '{% endraw %}'
-        ].join(" ")
+        ].join(' ')
       end
       begin
         self.data


### PR DESCRIPTION
Synopsis
- added support for `categories`
- added 'truer' booleans
- some stylistic code changes

I looked over quite a few jekyll frameworks and realized some used `tags` and others used `categories` due to different idea of how to utilize jekyll. So, I enhanced the if statement to account for that on **line 63**, and if any other are needed, they can be added easily into the word array. Next, I realized that the if a post had say `#+comments: true`, `true` would be made into a string, so I made it that if the value was only true or false, it would become that value (effectively making it so if the value is true, the value will remain a *boolean* true and same for false) on **line 72**. Lastly, rubocop was pestering me a lot, so I decided to follow it, but it was nothing major (eg making single quote strings when there's no string interpolation or special symbols, spaces).