### PR TITLE
change: Stricter regexps for _parse_boolean

### DIFF
--- a/lib/jekyll-org/converter.rb
+++ b/lib/jekyll-org/converter.rb
@@ -105,8 +105,8 @@ module Jekyll
         end
       end
 
-      @@truthy_regexps = [/enabled/,  /yes/, /true/]
-      @@falsy_regexps  = [/disabled/, /no/,  /false/]
+      @@truthy_regexps = [/^enabled$/,  /^yes$/, /^true$/]
+      @@falsy_regexps  = [/^disabled$/, /^no$/,  /^false$/]
 
       def _parse_boolean(value, error_msg=nil)
         case value.downcase


### PR DESCRIPTION
This avoids false positives when parsing front matter for booleans, such as the regex `/no/` matching a string such as "Weeknotes for week 14", which can result in lost titles, descriptions, etc.