### PR TITLE
Escape code block keywords in example post on readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,7 +74,12 @@ with Org. That is all! Generate your Jekyll site as you usually do.
 ** Front matter
 
 Instead of YAML the front matter is configured in the usual Org way,
-with no lines:
+with no lines.   
+
+Below is an example of an Org post, featuring front matter, tags, tables,
+liquid templating and syntax highlighting. To render this example, remove
+the leading hash symbols (#) at =#+begin_src= and =#+begin_end= beforehand
+(this is a workaround for GitHub's org rendering).
 
 #+BEGIN_EXAMPLE
 #+TITLE: Jekyll and Org together
@@ -100,14 +105,14 @@ This is a blog post about Jekyll and Org mode.
    
 ** Code highlighting
    Jekyll-org also offers powerful support for code snippets:
-   #+begin_src  ruby 
+   ##+begin_src  ruby 
      def print_hi(name)
        puts "Hi, #{name}"
      end
      print_hi('Tom')
 
      #=> prints 'Hi, Tom' to STDOUT.
-   #+end_src
+   ##+end_src
 #+END_EXAMPLE
 
 The value of =#+TAGS= is parsed into a list by splitting it on spaces,


### PR DESCRIPTION
Hey :) I've spent some time wondering why copy-pasting the example under "front matter" isn't working. Turns out it's because GitHub isn't rendering `#+begin_src` and `#+end_src` literally if they're inside an org `example` block. That wasn't quite obvious to me at first; I tried a couple of other tricks (using vanilla jekyll syntax, using reddit-like indentation) before it occurred to me.

Seeing that GitHub's org rendering is just too primitive (I have secretly wished [this](https://orgmode.org/manual/Escape-Character.html) will work), I think it's best to explicitly state that the block should be annotated like a regular org code block - for the sake of clarity, even if it comes at the cost of extra work for the user.

I hope this change may make it more obvious for other slow thinkers out there ;)